### PR TITLE
Mod GitHub actions(setup-gcloud)

### DIFF
--- a/.github/workflows/vscode-gcp-line-cicd.yml
+++ b/.github/workflows/vscode-gcp-line-cicd.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@master
         with:
           version: 'latest'
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/vscode-gcp-line-cicd.yml
+++ b/.github/workflows/vscode-gcp-line-cicd.yml
@@ -1,5 +1,5 @@
 name: GitHub Codespaces x LINE x GCP CI/CD
-  
+
 # This is a basic workflow that is manually triggered
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
@@ -30,7 +30,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           export_default_credentials: true
-          
+
       - name: Build
         run: |-
           gcloud builds submit \
@@ -44,4 +44,4 @@ jobs:
             --region "$RUN_REGION" \
             --image "gcr.io/$PROJECT_ID/$SERVICE_NAME" \
             --platform "managed"
-  
+


### PR DESCRIPTION
GitHub ActionsでWarningが出たので、参考までに修正プルリク作ってみました。

こちらで、変更されたようです。

https://github.com/google-github-actions/setup-gcloud/blob/b94035a6aac71cdacf6e682bbbef2e927960f8ac/setup-gcloud/README.md#googlecloudplatformgithub-actionssetup-gcloud-has-been-deprecated-please-use-google-github-actionssetup-gcloud

Warningのスクショが、こちら。
![image](https://user-images.githubusercontent.com/1247622/100714756-8c616b00-33f9-11eb-8a57-0538c28f8857.png)
